### PR TITLE
Doublons de quêtes

### DIFF
--- a/patches.txt
+++ b/patches.txt
@@ -2,3 +2,6 @@
 /bq e %player% Zedd.zae_obj4
 # Joueur qui ont leur magie bloquée dans des endroits où ils devraient pouvoir lancer des (au moins certains) sorts.
 /pex user %player% remove -Magic.cast.*
+# Joueur qui se retrouve avec un doublon de quête déjà terminée (peux surgir quand ils sont aux même endroit qu'un nouveau joueur qui fait sa quête)
+/bq journal %player% list # obtenir la liste des pointeurs de quête
+/bq journal %player% del [package.pointer] #retire un des pointeurs du journal (prévenir qu'il faut se regive le journal après)


### PR DESCRIPTION
Certains joueurs (notamment ceux qui se veulent "Helper" et qui font visiter les temples aux nouveaux joueurs) obtiennent des pages de quêtes déjà réalisées dans leur journal alors qu'ils l'ont déjà réalisée par le passé.

La démarche pour faire sauter la page en trop (en attendant de bugfix) est assez complexe, elle consiste à:
- _/bq journal %player% list_ pour obtenir la liste des pointeurs de quêtes (oui, pointeurs, ce qui veux dire qu'il faut décoder pour trouver le texte derrière)
- _/bq journal %player% del [package.pointer]_ pour effacer la page voulue.
- enfin, regive un journal tout propre à l'utilisateur, sinon, il se retrouve avec ça:
![biter](https://user-images.githubusercontent.com/5676901/33332323-4ee8c892-d464-11e7-9a44-a3ff429f5004.jpg)
